### PR TITLE
Remove hacky Chart.lock removal

### DIFF
--- a/.github/workflows/helm_lint_test.yaml
+++ b/.github/workflows/helm_lint_test.yaml
@@ -23,11 +23,6 @@ jobs:
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 
-        # Helm fails to find repository definition when Chart.lock exits,
-        # so this is a dirty hack to then fix once Helm handles this better.
-      - name: Remove Chart.lock
-        run: find . -type f -name 'Chart.lock' -exec rm "{}" +
-
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-rc.1
         with:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,2 @@
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
#### What this PR does / why we need it:

Previously I was unaware of how to handle the an error which stated that the repo was unavailable, however this can be solved using `ct.yaml`
